### PR TITLE
Add package.json to install dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.txt
-*.json
+analysisResults.json
+node_modules
 scripts/dev_*.sh
 tests/dlint/*_jalangi_.js
 tests/dlint/*_jalangi_.json

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ cd jalangi2
 rm -rf tmp
 mkdir tmp
 cd ../jalangi2analyses
+npm install
 ```
 
 Usage

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "jalangi2analyses",
+  "version": "0.0.1",
+  "description": "Analyses built on Jalangi 2",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ksen007/jalangi2analyses.git"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/ksen007/jalangi2analyses/issues"
+  },
+  "homepage": "https://github.com/ksen007/jalangi2analyses#readme",
+  "dependencies": {
+    "jsdom": "^3.1.2",
+    "xmldom": "^0.1.19"
+  }
+}


### PR DESCRIPTION
Also, update the README.md file to indicate that 'npm install' must be
run in the jalangi2analyses directory.

Fixes ksen007/jalangi2analyses#2
